### PR TITLE
Merge branches 'master' and 'remove-offline-plugin' of github.com:JetBrains/jetbrains_guide into remove-offline-plugin

### DIFF
--- a/packages/gatsby-theme-bulmaio/gatsby-config.js
+++ b/packages/gatsby-theme-bulmaio/gatsby-config.js
@@ -4,7 +4,6 @@ module.exports = {
         `gatsby-plugin-react-helmet`,
         `gatsby-plugin-sharp`,
         `gatsby-plugin-typescript`,
-        `gatsby-plugin-offline`,
         `gatsby-transformer-yaml`,
         'gatsby-plugin-sass',
         {

--- a/packages/gatsby-theme-bulmaio/package.json
+++ b/packages/gatsby-theme-bulmaio/package.json
@@ -15,7 +15,6 @@
     "gatsby": "2.15.14",
     "gatsby-image": "^2.2.36",
     "gatsby-plugin-gtag": "^1.0.11",
-    "gatsby-plugin-offline": "3.0.6",
     "gatsby-plugin-react-helmet": "^3.0.12",
     "gatsby-plugin-sass": "^2.0.11",
     "gatsby-plugin-sharp": "2.2.1",


### PR DESCRIPTION
Remove usage of the offline plugin in Gatsby.