### PR TITLE
Add tutorial sidebar with all steps

### DIFF
--- a/packages/gatsby-theme-bulmaio/src/resources/tutorial/Tutorial.tsx
+++ b/packages/gatsby-theme-bulmaio/src/resources/tutorial/Tutorial.tsx
@@ -9,6 +9,8 @@ import { TwitterCardPage } from '../../components/layout/MasterLayout';
 import { TutorialSidebar } from './TutorialSidebar';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import ResourceCard from '../../components/resourcecard/ResourceCard';
+import {TutorialStepSidebar} from "../tutorialstep/TutorialStepSidebar";
+import {Step} from "../../components/sidebar/SidebarSteps";
 
 export interface TutorialProps {
   location: {
@@ -39,10 +41,19 @@ const Tutorial: FC<TutorialProps> = (
             : ''
   };
 
+  // #### Sidebar steps
+  const steps: Step[] = tutorial.tutorialItems.map((item: any) => (
+      {
+        label: item.title,
+        href: item.slug
+      }
+  ));
+
   // #### Sidebar
   const sidebar = <TutorialSidebar
     author={tutorial.author}
     date={tutorial.date}
+    steps={steps}
     products={tutorial.products}
     technologies={tutorial.technologies}
     topics={tutorial.topics}

--- a/packages/gatsby-theme-bulmaio/src/resources/tutorial/TutorialSidebar.tsx
+++ b/packages/gatsby-theme-bulmaio/src/resources/tutorial/TutorialSidebar.tsx
@@ -6,17 +6,19 @@ import { ResourceCardAuthorProps } from '../../components/resourcecard/author/Re
 import { ResourceCardTechnologies } from '../../components/resourcecard/technology/ResourceCardTechnologies';
 import { ResourceCardTopics } from '../../components/resourcecard/topic/ResourceCardTopics';
 import { ResourceCardProducts } from '../../components/resourcecard/product/ResourceCardProducts';
+import SidebarSteps from "../../components/sidebar/SidebarSteps";
 
 export interface TutorialSidebarProps {
   author: ResourceCardAuthorProps;
   date: string;
+  steps: any[];
   products: ResourceCardProducts;
   technologies: ResourceCardTechnologies;
   topics: ResourceCardTopics;
 }
 
 export const TutorialSidebar: React.FC<TutorialSidebarProps> = (
-  { author, date, products, technologies, topics }
+  { author, date, products, technologies, topics, steps }
 ) => {
   const published: SidebarPublishedProps = {
     date: date,
@@ -38,6 +40,8 @@ export const TutorialSidebar: React.FC<TutorialSidebarProps> = (
       <SidebarReferencesGroup
         reftype={`topics`} accent={`success`}
         references={topics ? topics.map(t => t.label) : []}
+      />
+      <SidebarSteps currentSlug="" steps={steps}
       />
     </Sidebar>
   );

--- a/packages/gatsby-theme-bulmaio/src/resources/tutorialstep/TutorialStepSidebar.tsx
+++ b/packages/gatsby-theme-bulmaio/src/resources/tutorialstep/TutorialStepSidebar.tsx
@@ -5,8 +5,8 @@ import SidebarReferencesGroup from '../../components/sidebar/SidebarReferencesGr
 import { ResourceCardAuthorProps } from '../../components/resourcecard/author/ResourceCardAuthor';
 import { ResourceCardTechnologies } from '../../components/resourcecard/technology/ResourceCardTechnologies';
 import { ResourceCardTopics } from '../../components/resourcecard/topic/ResourceCardTopics';
-import SidebarSteps from '../../components/sidebar/SidebarSteps';
 import { ResourceCardProducts } from '../../components/resourcecard/product/ResourceCardProducts';
+import SidebarSteps from '../../components/sidebar/SidebarSteps';
 
 export interface TutorialstepSidebarProps {
   author: ResourceCardAuthorProps;


### PR DESCRIPTION
Not sure we want to merge, but I always look for the sidebar on tutorial overview pages and I miss it!

Before:
![image](https://user-images.githubusercontent.com/485230/107001557-1fb47500-678a-11eb-8715-48e67d39a294.png)

After:
![image](https://user-images.githubusercontent.com/485230/107001571-2511bf80-678a-11eb-8651-8cf3b12ceded.png)
