### PR TITLE
Experiment for embedding YouTube videos as GIFs

### DIFF
--- a/packages/gatsby-theme-bulmaio/src/components/video/LongVideo.tsx
+++ b/packages/gatsby-theme-bulmaio/src/components/video/LongVideo.tsx
@@ -8,9 +8,12 @@ export const LongVideo: React.FC<VideoPlayerProps> = (
   { video }
 ) => {
 
+  // TODO(florin): Improve this code if it makes it to production
+  interface videoPlayerOptions {}
+
   if (video) {
-    const options = {
-      controls: true,
+    let options: videoPlayerOptions = {
+      controls: 1,
       poster: video.posterURL,
       fill: true,
       sources: [
@@ -20,6 +23,20 @@ export const LongVideo: React.FC<VideoPlayerProps> = (
         }
       ]
     };
+
+    if (video.likeGIF) {
+      options = {
+        ...options,
+        controls: 0,
+        modestbranding: 0,
+        playsinline: 1,
+        disablekb: 1,
+        autoplay: 1,
+        rel: 0,
+        fs: 0,
+      }
+    }
+
     return (
       <Element name="full-video" className="element" style={{ marginTop: '1rem' }}>
         <header style={{marginBottom: '1rem'}} className="is-size-3 is-bold">Full Video</header>

--- a/packages/gatsby-theme-bulmaio/src/components/video/ShortVideo.tsx
+++ b/packages/gatsby-theme-bulmaio/src/components/video/ShortVideo.tsx
@@ -6,9 +6,12 @@ export const ShortVideo: React.FC<VideoPlayerProps> = (
   { video }
 ) => {
 
+  // TODO(florin): Improve this code if it makes it to production
+  interface videoPlayerOptions {}
+
   if (video) {
-    const options = {
-      controls: true,
+    let options: videoPlayerOptions = {
+      controls: 1,
       poster: video.posterURL,
       sources: [
         {
@@ -17,6 +20,19 @@ export const ShortVideo: React.FC<VideoPlayerProps> = (
         }
       ]
     };
+    if (video.likeGIF) {
+      options = {
+        ...options,
+        controls: 0,
+        modestbranding: 0,
+        playsinline: 1,
+        disablekb: 1,
+        autoplay: 1,
+        rel: 0,
+        fs: 0,
+      }
+    }
+
     return (
       <div className="column is-three-fifths">
         <VideoPlayer {...options} />

--- a/packages/gatsby-theme-bulmaio/src/components/video/models.ts
+++ b/packages/gatsby-theme-bulmaio/src/components/video/models.ts
@@ -2,6 +2,7 @@ export interface VideoPlayerProps {
   video?: {
     posterURL: string;
     youtubeURL: string;
+    likeGIF: boolean;
   }
 }
 
@@ -11,4 +12,5 @@ export interface Video {
     publicURL: string;
     childImageSharp: any;
   };
+  likeGIF: boolean;
 }

--- a/packages/gatsby-theme-bulmaio/src/components/video/videoFragment.ts
+++ b/packages/gatsby-theme-bulmaio/src/components/video/videoFragment.ts
@@ -2,6 +2,7 @@ import { graphql } from 'gatsby';
 
 export const videoFragment = graphql`
   fragment VideoFragment on Video {
+    likeGIF
     url
     poster {
       publicURL

--- a/packages/gatsby-theme-bulmaio/src/resources/tip/Tip.tsx
+++ b/packages/gatsby-theme-bulmaio/src/resources/tip/Tip.tsx
@@ -115,7 +115,8 @@ const Tip: FC<TipProps> = (
         {shortVideo && <ShortVideo video={
           {
             posterURL: shortVideo.poster ? shortVideo.poster.publicURL : '',
-            youtubeURL: shortVideo.url
+            youtubeURL: shortVideo.url,
+            likeGIF: shortVideo.likeGIF ? shortVideo.likeGIF : false,
           }} />
         }
         <div
@@ -174,7 +175,8 @@ const Tip: FC<TipProps> = (
         <LongVideo video={
           {
             posterURL: longVideo.poster.publicURL,
-            youtubeURL: longVideo.url
+            youtubeURL: longVideo.url,
+            likeGIF: longVideo.likeGIF ? longVideo.likeGIF : false,
           }} />
       )}
 


### PR DESCRIPTION
This change allows embedding YouTube videos as they would be GIF images.
Some additional code clean-up might be needed, but for now, all of it is under a feature flag.
If we decide it's useful and start using this, I'll do the said cleanup work.