### PR TITLE
Fix project loading error due to missing iml 

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/guide.iml" filepath="$PROJECT_DIR$/.idea/guide.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/jetbrains_guide.iml" filepath="$PROJECT_DIR$/.idea/jetbrains_guide.iml" />
     </modules>
   </component>


### PR DESCRIPTION
This resolves the missing iml file issue and makes our IDEs happy when loading the project.