### PR TITLE
WebStorm: update tips

### DIFF
--- a/sites/webstorm-guide/contents/tips/distraction-free/index.md
+++ b/sites/webstorm-guide/contents/tips/distraction-free/index.md
@@ -1,4 +1,5 @@
 ---
+hasBody: true
 date: 2020-03-16
 title: Make Your Work Environment Distraction Free
 subtitle: Need to focus on just your code? You can switch to the distraction-free or zen mode.
@@ -15,7 +16,7 @@ animatedGif:
     width: 600
     height: 300
 leadin: |
-- Switch to the **Distraction-free** mode with *Ctrl+` | View Mode | Enter Distraction Free Mode* 
+  Switch to the **Distraction-free** mode with *Ctrl+` | View Mode | Enter Distraction Free Mode* 
   whenever you need to focus on coding – you’ll get the source code centered and 
   all the UI elements hidden.
 
@@ -23,3 +24,4 @@ leadin: |
   full screen and distraction-free modes by entering the **Zen** mode: *Ctrl+` | View Mode | Enter Zen Mode.*
 
   To exit the modes, hit *Ctrl+`* and navigate to *View Mode | Exit Distraction Free (or Zen) Mode.*
+---

--- a/sites/webstorm-guide/contents/tips/distraction-free/index.md
+++ b/sites/webstorm-guide/contents/tips/distraction-free/index.md
@@ -15,11 +15,11 @@ animatedGif:
     width: 600
     height: 300
 leadin: |
-  Switch to the **distraction-free** mode with *Ctrl+` | View Mode | Enter Distraction Free Mode* 
+- Switch to the **Distraction-free** mode with *Ctrl+` | View Mode | Enter Distraction Free Mode* 
   whenever you need to focus on coding – you’ll get the source code centered and 
-  all the UI elements hidden. 
-  
-  If you Want to get rid of every part of the IDE except your code, you can combine the 
-  full screen and distraction-free modes by entering the **Zen** mode: *Ctrl+` | View Mode | Enter Zen Mode*.
+  all the UI elements hidden.
 
-  To exit the modes, hit *Ctrl+` and navigate to | View Mode | Exit Distraction Free (or zen) Mode* 
+  If you want to get rid of every part of the IDE except your code, you can combine the 
+  full screen and distraction-free modes by entering the **Zen** mode: *Ctrl+` | View Mode | Enter Zen Mode.*
+
+  To exit the modes, hit *Ctrl+`* and navigate to *View Mode | Exit Distraction Free (or Zen) Mode.*

--- a/sites/webstorm-guide/contents/tips/distraction-free/index.md
+++ b/sites/webstorm-guide/contents/tips/distraction-free/index.md
@@ -20,5 +20,6 @@ leadin: |
   all the UI elements hidden. 
   
   If you Want to get rid of every part of the IDE except your code, you can combine the 
-  full screen and distraction-free modes by entering the **Zen** mode:  
-  *Ctrl+` | View Mode | Enter Zen Mode*
+  full screen and distraction-free modes by entering the **Zen** mode: *Ctrl+` | View Mode | Enter Zen Mode*.
+
+  To exit the modes, hit *Ctrl+` and navigate to | View Mode | Exit Distraction Free (or zen) Mode* 

--- a/sites/webstorm-guide/contents/tips/monitor-incoming-and-outgoing-commits/index.md
+++ b/sites/webstorm-guide/contents/tips/monitor-incoming-and-outgoing-commits/index.md
@@ -14,3 +14,4 @@ screenshot: ./card.jpeg
 leadin: |
   The blue icon next to the branch name in the Branches popup will let you know if this branch has any new incoming commits,
   while the green icon will let you know if the branch has outgoing commits.
+---

--- a/sites/webstorm-guide/contents/tips/monitor-incoming-and-outgoing-commits/index.md
+++ b/sites/webstorm-guide/contents/tips/monitor-incoming-and-outgoing-commits/index.md
@@ -12,4 +12,5 @@ thumbnail: ./thumbnail.jpeg
 cardThumbnail: ./card.png
 screenshot: ./card.jpeg
 leadin: |
-  The blue icon next to the branch name in the Branches popup will let you know if this branch has any new incoming commits.
+  The blue icon next to the branch name in the Branches popup will let you know if this branch has any new incoming commits,
+  while the green icon will let you know if the branch has outgoing commits.

--- a/sites/webstorm-guide/contents/tips/monitor-incoming-and-outgoing-commits/index.md
+++ b/sites/webstorm-guide/contents/tips/monitor-incoming-and-outgoing-commits/index.md
@@ -2,7 +2,7 @@
 date: 2021-06-11
 title: Monitor Incoming and Outgoing Commits
 technologies: []
-topics: [editing]
+topics: [vcs]
 author: ed
 subtitle: Want to know if your branch has new commits? Here's how.
 seealso:


### PR DESCRIPTION
## What does this PR do?
- adds how to exit distraction-free/zen modes
- moves incoming/outgoing commits tip to vcs