### PR TITLE
Add a shell script for i10n automation

### DIFF
--- a/i10n.sh
+++ b/i10n.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+guide=""
+
+case "$1" in
+    intellij)
+
+      guide="intellij" ;;
+    dotnet)
+      guide="dotnet" ;;
+    go)
+      guide="go" ;;
+    ws)
+      guide="ws" ;;
+    pc)
+      guide="pc" ;;
+esac
+
+if [ $guide == "" ] ; then
+    echo 'Missing argument for guide'
+    exit 1
+else
+  cp -r ./zh-CN/sites/$guide-guide/contents/* ./sites/$guide-guide/contents/
+fi

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "dotnet:clean": "yarn workspace dotnet-guide clean",
     "intellij:develop": "yarn workspace intellij-guide develop",
     "intellij:build": "yarn workspace intellij-guide build",
-    "intellij:clean": "yarn workspace intellij-guide clean"
+    "intellij:clean": "yarn workspace intellij-guide clean",
+    "intellij:cn": "./i10n.sh intellij"
   },
   "dependencies": {
     "yarn": "^1.22.11"


### PR DESCRIPTION
The plan is that when the translation ready, we can use something like `npm run <guide>:<locale>` and trigger the shell script to copy the Markdown file from the locale folder to original English folder in locale branch.