### PR TITLE
Changed keys for finding next occurance for macOS

### DIFF
--- a/sites/intellij-guide/contents/tips/find-next-word/index.md
+++ b/sites/intellij-guide/contents/tips/find-next-word/index.md
@@ -14,7 +14,7 @@ seealso:
   - title: IntelliJ IDEA Help - Source code navigation
     href: https://www.jetbrains.com/help/idea/navigating-through-the-source-code.html
 leadin: |
-  Press **⌘G** (macOS), or **F3** (Windows/Linux), to move to the next occurrence of a word. 
+  Press **^G** (macOS), or **F3** (Windows/Linux), to move to the next occurrence of a word. 
 
   **Pro tip:**
   


### PR DESCRIPTION
The tip for selecting the next occurrence of a word appears to be outdated. I found it needs to be CTRL + G (^G) instead of ⌘G.

Tested with macOS Monterey 12.1