### PR TITLE
Re-enable pagination after Gatsby updates

### DIFF
--- a/packages/gatsby-theme-bulmaio/src/components/Pagination.tsx
+++ b/packages/gatsby-theme-bulmaio/src/components/Pagination.tsx
@@ -1,30 +1,30 @@
 import React, { FC } from 'react';
-
-// import { Link } from 'gatsby';
+import { Link } from 'gatsby';
 
 interface PaginationProps {
   numPages: number;
   prefix: string;
 }
 
-const Pagination: FC<PaginationProps> = ({ numPages, prefix }) => (
-  // TODO Re-enable this for 2.1
-  <div />
+const Pagination: FC<PaginationProps> = (
+  { numPages, prefix }
+) => (
+  <nav className="mt-5 pagination is-small" role="navigation" aria-label="pagination">
+    <ul className="pagination-list">
+      {numPages > 1 && (
+          /*@ts-ignore*/Array.from({ length: numPages }, (_, i) => (
+          <li>
+            <Link key={`pagination-number${i + 1}`}
+                  to={`/${prefix}/${i === 0 ? '' : i + 1}`}
+                  style={{ minWidth: 'auto' }}
+                  className={`pagination-link`}>
+              {i + 1}
+            </Link>
+          </li>
+          ))
+      )}
+    </ul>
+  </nav>
 );
-// const Pagination: FC<PaginationProps> = (
-//   { numPages, prefix }
-// ) => (
-//   <div>
-//     {Array.from({ length: numPages }, (_, i) => (
-//       <Link
-//         key={`pagination-number${i + 1}`}
-//         to={`/${prefix}/${i === 0 ? '' : i + 1}`}
-//         style={{ paddingRight: '1em' }}
-//       >
-//         {i + 1}
-//       </Link>
-//     ))}
-//   </div>
-// );
 
 export default Pagination;

--- a/packages/gatsby-theme-bulmaio/src/references/gatsby-setup.ts
+++ b/packages/gatsby-theme-bulmaio/src/references/gatsby-setup.ts
@@ -21,7 +21,7 @@ async function createListing(graphql: any, createPage: any, referenceType: strin
     }
   `);
     const allResults = allResultsData.data[allType].nodes;
-    const entriesPerPage = 200;  // TODO Lower me
+    const entriesPerPage = 25;
     const numPages = Math.ceil(allResults.length / entriesPerPage);
     Array.from({length: numPages}).forEach((_, i) => {
         createPage({

--- a/packages/gatsby-theme-bulmaio/src/resources/gatsby-setup.ts
+++ b/packages/gatsby-theme-bulmaio/src/resources/gatsby-setup.ts
@@ -23,7 +23,7 @@ async function createListing(graphql: any, createPage: any, resourceType: string
     }
   `);
     const allResults = allResultsData.data[allType].nodes;
-    const entriesPerPage = 200;  // TODO Lower me
+    const entriesPerPage = 25;
     const numPages = Math.ceil(allResults.length / entriesPerPage);
     Array.from({length: numPages}).forEach((_, i) => {
         createPage({


### PR DESCRIPTION
Here's what it looks like:
![image](https://user-images.githubusercontent.com/485230/229492526-6775047f-c279-4e5e-b461-6c9242ce9218.png)
